### PR TITLE
fix hour whitespace in rinsland header

### DIFF
--- a/spector/io/_iofmt.py
+++ b/spector/io/_iofmt.py
@@ -179,7 +179,7 @@ rinsland_header_regex = (
     "(?P<aperture>[\d.]+) mm "
     "Ap.ZA=(?P<zenith_angle>[\d.]+) "
     "S/N=(?P<sn_ratio>[\d ]+) "
-    "h=(?P<hour_avg>[\d.]+)"
+    "h=\s*(?P<hour_avg>[\d.]+)"
 )
 
 


### PR DESCRIPTION
A fix when hour contain whitespace(s) in the rinsland header.